### PR TITLE
Export dynamic symbols for the Fortran interfaces to C

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,19 @@ complex_bessel
 [![Join the chat at https://gitter.im/valandil/complex_bessel](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/valandil/complex_bessel?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![DOI](https://zenodo.org/badge/5354/valandil/complex_bessel.svg)](https://zenodo.org/badge/latestdoi/5354/valandil/complex_bessel)
 
-A C++ library to evaluate Bessel functions of all kinds. More information can 
-be found on the [website](http://joeydumont.github.io/complex_bessel).
+A C++ library to evaluate Bessel functions of all kinds. More information can  be found on the [website](http://joeydumont.github.io/complex_bessel).
 
 ## Introduction
 
-C++ library that acts as a wrapper for the Fortran subroutines developed by D.E. Amos.
-The library provides functionality to compute the Bessel, Hankel and Airy functions of
-complex argument and real order. Negative orders are implemented via the standard formulae.
+C++ library that acts as a wrapper for the Fortran subroutines developed by D.E. Amos. The library provides functionality to compute the Bessel, Hankel and Airy functions of complex argument and real order. Negative orders are implemented via the standard formulae.
 
 We provide a shared object library and header files to be included.
 
 ## Compilation instructions
 
-The library uses CMake for compilation. The user should thus install CMake
-on their machine. On Ubuntu and other Debian-based OSes, this can be done
-by running
+### Linux
+
+The library uses CMake for compilation. The user should thus install CMake on their machine. On Ubuntu and other Debian-based OSes, this can be done by running
   ```bash
   sudo apt-get install cmake
   ```
@@ -28,18 +25,7 @@ On Arch Linux
   sudo pacman -S cmake
   ```
 
-The user should then run
-  ```bash
-  bash build.sh
-  ```
-which will create a `build/` directory and run make automatically. When
-you are ready to install the files, just run 
-  ```bash
-  cd build
-  sudo make install
-  ```
-The library will be installed to `/usr` by default. To change
-it, you will have to run `cmake` manually like so:
+We suggest doing an out-of-tree build by first creating a `build/` folder, then running cmake, i.e.
   ```bash
   cmake -DCMAKE_INSTALL_PREFIX=/path/of/install/dir
  ```
@@ -49,7 +35,7 @@ as `complex_bessel::complex_bessel` to a package configuration file for this
 library.
 
 After installation you can find this library in your
-project CMakeLists.txt with:
+project `CMakeLists.txt` with:
   ```cmake
   find_package(complex_bessel)
 ```
@@ -64,16 +50,20 @@ After that to link with your `<target>` you can just
   ```cmake
   target_link_library(<target> complex_bessel::complex_bessel)
 ```
-Note, that CMake will add all additional needed include
-files to you project compilation automatically.
+Note that CMake will add all additional needed include files to you project compilation automatically.
 
-To run tests you will need to use HDF5 , Google Test, Boost 1.6+, and C compiler (to link with HDF5, so `C` is present in the list of languages in tests/CMakeLists.txt)
+To run tests you will need to use HDF5, Google Test, Boost 1.6+, and a C compiler (to link with HDF5, so `C` is present in the list of languages in tests/CMakeLists.txt)
 
- ## Other similar libraries
+###  Windows (experimental support)
+
+There is currently experimental support for compiling with Visual Studio Code. The only tested configuration is with the Intel OneAPI Fortran compiler, installed with Visual Studio integration. The project compiles, but nothing else is tested. Feel free to open a PR for better Windows support.
+
+
+## Other similar libraries
  
- The FORTRAN library that is used as the main driver for the computation of Bessel functions is also used in
-   * [`scipy.special`](https://docs.scipy.org/doc/scipy/reference/special.html)
-   * MATLAB
+The FORTRAN library that is used as the main driver for the computation of Bessel functions is also used in
+  * [`scipy.special`](https://docs.scipy.org/doc/scipy/reference/special.html)
+  * MATLAB
    
 [Boost](https://www.boost.org/doc/libs/1_72_0/libs/math/doc/html/math_toolkit/bessel/bessel_first.html) has its own implementation of the Bessel functions, but only supports real values for the argument.
 

--- a/src/amos_iso_c_fortran_wrapper.f90
+++ b/src/amos_iso_c_fortran_wrapper.f90
@@ -1,8 +1,8 @@
 ! -------------------------------------------------------------------
-! - Author: 		Joey Dumont <joey.dumont@gmail.com>         -
+! - Author:             Joey Dumont <joey.dumont@gmail.com>         -
 !                       Denis Gagnon <gagnon88@gmail.com>           -
-! - Date created:	2013-11-18                                  -
-! - Date modded:	2015-02-26                                  -
+! - Date created:       2013-11-18                                  -
+! - Date modded:        2015-02-26                                  -
 ! - Description:        ISO C Binding wrapper for the FORTRAN       -
 !                       subroutines contained in D. E. Amos' Bessel -
 !                       functions library.                          -
@@ -10,169 +10,176 @@
 
 ! Bessel function of the first kind.
 subroutine zbesj_wrap(zr, zi, order, kode, N, cyr, cyi, nz, ierr) bind(C)
+    !DEC$ ATTRIBUTES DLLEXPORT :: zbesj_wrap
 
-                ! State ISO_C_BINDING and no implicit variable types.
-                use iso_c_binding
-                implicit none
+    ! State ISO_C_BINDING and no implicit variable types.
+    use iso_c_binding
+    implicit none
 
-                ! State intent of FORTRAN variables.
-                real(c_double), value, intent(in)     :: zr, zi, order
-                integer(c_int), value, intent(in)     :: kode, N
-                real(c_double), intent(out)           :: cyr, cyi
-                integer(c_int), intent(out)           :: nz, ierr
+    ! State intent of FORTRAN variables.
+    real(c_double), value, intent(in)     :: zr, zi, order
+    integer(c_int), value, intent(in)     :: kode, N
+    real(c_double), intent(out)           :: cyr, cyi
+    integer(c_int), intent(out)           :: nz, ierr
 
-                ! Interface to original FORTRAN subroutine.
-                interface
-                        SUBROUTINE ZBESJ(ZR, ZI, ORDER, KODE, N, CYR, CYI, NZ, IERR)
-                                INTEGER KODE, N, NZ, IERR
-                                DOUBLE PRECISION ZR, ZI, ORDER, CYR, CYI
-                        END SUBROUTINE ZBESJ
-                end interface
-
-                call ZBESJ(zr, zi, order, kode, N, cyr, cyi, nz, ierr)
+    ! Interface to original FORTRAN subroutine.
+    interface
+            SUBROUTINE ZBESJ(ZR, ZI, ORDER, KODE, N, CYR, CYI, NZ, IERR)
+                    INTEGER KODE, N, NZ, IERR
+                    DOUBLE PRECISION ZR, ZI, ORDER, CYR, CYI
+            END SUBROUTINE ZBESJ
+    end interface
+    
+    call ZBESJ(zr, zi, order, kode, N, cyr, cyi, nz, ierr)
 end subroutine zbesj_wrap
 
 ! Bessel function of the second kind.
 subroutine zbesy_wrap(zr, zi, order, kode, N, cyr, cyi, nz, cwrkr, cwrki, ierr) bind(C)
+    !DEC$ ATTRIBUTES DLLEXPORT :: zbesy_wrap
 
-                ! State ISO_C_BINDING and no implicit variable types.
-                use iso_c_binding
-                implicit none
+    ! State ISO_C_BINDING and no implicit variable types.
+    use iso_c_binding
+    implicit none
 
-                ! State intent of FORTRAN variables.
-                real(c_double), value, intent(in)      :: zr, zi, order
-                integer(c_int), value, intent(in)      :: kode, N
-                real(c_double), intent(out)            :: cyr, cyi
-                real(c_double), intent(in)             :: cwrkr, cwrki
-                integer(c_int), intent(out)            :: nz, ierr
+    ! State intent of FORTRAN variables.
+    real(c_double), value, intent(in)      :: zr, zi, order
+    integer(c_int), value, intent(in)      :: kode, N
+    real(c_double), intent(out)            :: cyr, cyi
+    real(c_double), intent(in)             :: cwrkr, cwrki
+    integer(c_int), intent(out)            :: nz, ierr
 
-                ! Interface to original FORTRAN subroutine.
-                interface
-                        SUBROUTINE ZBESY(ZR, ZI, ORDER, KODE, N, CYR, CYI, NZ, CWRKR, CWRKI, IERR)
-                                INTEGER KODE, N, NZ, IERR
-                                DOUBLE PRECISION ZR, ZI, ORDER, CYR, CYI, CWRKR, CWRKI
-                        END SUBROUTINE ZBESY
-                end interface
+    ! Interface to original FORTRAN subroutine.
+    interface
+            SUBROUTINE ZBESY(ZR, ZI, ORDER, KODE, N, CYR, CYI, NZ, CWRKR, CWRKI, IERR)
+                    INTEGER KODE, N, NZ, IERR
+                    DOUBLE PRECISION ZR, ZI, ORDER, CYR, CYI, CWRKR, CWRKI
+            END SUBROUTINE ZBESY
+    end interface
 
-                call ZBESY(zr, zi, order, kode, N, cyr, cyi, nz, cwrkr, cwrki, ierr)
+    call ZBESY(zr, zi, order, kode, N, cyr, cyi, nz, cwrkr, cwrki, ierr)
 end subroutine zbesy_wrap
 
 ! Modified Bessel function of the first kind.
 subroutine zbesi_wrap(zr, zi, order, kode, N, cyr, cyi, nz, ierr) bind(C)
+    !DEC$ ATTRIBUTES DLLEXPORT :: zbesi_wrap
 
-                ! State ISO_C_BINDING and no implicit variable types.
-                use iso_c_binding
-                implicit none
+    ! State ISO_C_BINDING and no implicit variable types.
+    use iso_c_binding
+    implicit none
 
-                ! State intent of FORTRAN variables.
-                real(c_double), value, intent(in)      :: zr, zi, order
-                integer(c_int), value, intent(in)       :: kode, N
-                real(c_double), intent(out)            :: cyr, cyi
-                integer(c_int), intent(out)             :: nz, ierr
+    ! State intent of FORTRAN variables.
+    real(c_double), value, intent(in)      :: zr, zi, order
+    integer(c_int), value, intent(in)       :: kode, N
+    real(c_double), intent(out)            :: cyr, cyi
+    integer(c_int), intent(out)             :: nz, ierr
 
-                ! Interface to original FORTRAN subroutine.
-                interface
-                        SUBROUTINE ZBESI(ZR, ZI, ORDER, KODE, N, CYR, CYI, NZ, IERR)
-                                INTEGER KODE, N, NZ, IERR
-                                DOUBLE PRECISION ZR, ZI, ORDER, CYR, CYI
-                        END SUBROUTINE ZBESI
-                end interface
+    ! Interface to original FORTRAN subroutine.
+    interface
+            SUBROUTINE ZBESI(ZR, ZI, ORDER, KODE, N, CYR, CYI, NZ, IERR)
+                    INTEGER KODE, N, NZ, IERR
+                    DOUBLE PRECISION ZR, ZI, ORDER, CYR, CYI
+            END SUBROUTINE ZBESI
+    end interface
 
-                call ZBESI(zr, zi, order, kode, N, cyr, cyi, nz, ierr)
+    call ZBESI(zr, zi, order, kode, N, cyr, cyi, nz, ierr)
 end subroutine zbesi_wrap
 
 ! Modified Bessel function of the second kind.
 subroutine zbesk_wrap(zr, zi, order, kode, N, cyr, cyi, nz, ierr) bind(C)
+    !DEC$ ATTRIBUTES DLLEXPORT :: zbesk_wrap
 
-                ! State ISO_C_BINDING and no implicit variable types.
-                use iso_c_binding
-                implicit none
+    ! State ISO_C_BINDING and no implicit variable types.
+    use iso_c_binding
+    implicit none
 
-                ! State intent of FORTRAN variables.
-                real(c_double), value, intent(in)     :: zr, zi, order
-                integer(c_int), value, intent(in)     :: kode, N
-                real(c_double), intent(out)           :: cyr, cyi
-                integer(c_int), intent(out)           :: nz, ierr
+    ! State intent of FORTRAN variables.
+    real(c_double), value, intent(in)     :: zr, zi, order
+    integer(c_int), value, intent(in)     :: kode, N
+    real(c_double), intent(out)           :: cyr, cyi
+    integer(c_int), intent(out)           :: nz, ierr
 
-                ! Interface to original FORTRAN subroutine.
-                interface
-                        SUBROUTINE ZBESK(ZR, ZI, ORDER, KODE, N, CYR, CYI, NZ, IERR)
-                                INTEGER KODE, N, NZ, IERR
-                                DOUBLE PRECISION ZR, ZI, ORDER, CYR, CYI
-                        END SUBROUTINE ZBESK
-                end interface
+    ! Interface to original FORTRAN subroutine.
+    interface
+            SUBROUTINE ZBESK(ZR, ZI, ORDER, KODE, N, CYR, CYI, NZ, IERR)
+                    INTEGER KODE, N, NZ, IERR
+                    DOUBLE PRECISION ZR, ZI, ORDER, CYR, CYI
+            END SUBROUTINE ZBESK
+    end interface
 
-                call ZBESK(zr, zi, order, kode, N, cyr, cyi, nz, ierr)
+    call ZBESK(zr, zi, order, kode, N, cyr, cyi, nz, ierr)
 end subroutine zbesk_wrap
 
 ! Hankel functions of both kinds.
 subroutine zbesh_wrap(zr, zi, order, kode, M, N, cyr, cyi, nz, ierr) bind(C)
+    !DEC$ ATTRIBUTES DLLEXPORT :: zbesh_wrap
 
-                ! State ISO_C_BINDING and no implicit variable types.
-                use iso_c_binding
-                implicit none
+    ! State ISO_C_BINDING and no implicit variable types.
+    use iso_c_binding
+    implicit none
 
-                ! State intent of FORTRAN variables.
-                real(c_double), value, intent(in)      :: zr, zi, order
-                integer(c_int), value, intent(in)      :: kode, M, N
-                real(c_double), intent(out)            :: cyr, cyi
-                integer(c_int), intent(out)            :: nz, ierr
+    ! State intent of FORTRAN variables.
+    real(c_double), value, intent(in)      :: zr, zi, order
+    integer(c_int), value, intent(in)      :: kode, M, N
+    real(c_double), intent(out)            :: cyr, cyi
+    integer(c_int), intent(out)            :: nz, ierr
 
-                ! Interface to original FORTRAN subroutine.
-                interface
-                        SUBROUTINE ZBESH(ZR, ZI, ORDER, KODE, M, N, CYR, CYI, NZ, IERR)
-                                INTEGER KODE, M, N, NZ, IERR
-                                DOUBLE PRECISION ZR, ZI, ORDER, CYR, CYI
-                        END SUBROUTINE ZBESH
-                end interface
+    ! Interface to original FORTRAN subroutine.
+    interface
+            SUBROUTINE ZBESH(ZR, ZI, ORDER, KODE, M, N, CYR, CYI, NZ, IERR)
+                    INTEGER KODE, M, N, NZ, IERR
+                    DOUBLE PRECISION ZR, ZI, ORDER, CYR, CYI
+            END SUBROUTINE ZBESH
+    end interface
 
-                call ZBESH(zr, zi, order, kode, M, N, cyr, cyi, nz, ierr)
+    call ZBESH(zr, zi, order, kode, M, N, cyr, cyi, nz, ierr)
 end subroutine zbesh_wrap
 
 ! Airy function of the first kind.
 subroutine zairy_wrap(zr, zi, id, kode, air, aii, nz, ierr) bind(C)
+    !DEC$ ATTRIBUTES DLLEXPORT :: zairy_wrap
 
-                ! State ISO_C_BINDING and no implicit variable types.
-                use iso_c_binding
-                implicit none
+    ! State ISO_C_BINDING and no implicit variable types.
+    use iso_c_binding
+    implicit none
 
-                ! State intent of FORTRAN variables.
-                real(c_double), value, intent(in)               :: zr, zi
-                integer(c_int), value, intent(in)               :: id, kode
-                real(c_double), intent(out)                     :: air, aii
-                integer(c_int), intent(out)                     :: nz, ierr
+    ! State intent of FORTRAN variables.
+    real(c_double), value, intent(in)               :: zr, zi
+    integer(c_int), value, intent(in)               :: id, kode
+    real(c_double), intent(out)                     :: air, aii
+    integer(c_int), intent(out)                     :: nz, ierr
 
-                ! Interface to original FORTRAN subroutine.
-                interface
-                        SUBROUTINE ZAIRY(ZR, ZI, ID, KODE, AIR, AII, NZ, IERR)
-                                INTEGER ID, KODE, NZ, IERR
-                                DOUBLE PRECISION ZR, ZI, AIR, AII
-                        END SUBROUTINE ZAIRY
-                end interface
+    ! Interface to original FORTRAN subroutine.
+    interface
+            SUBROUTINE ZAIRY(ZR, ZI, ID, KODE, AIR, AII, NZ, IERR)
+                    INTEGER ID, KODE, NZ, IERR
+                    DOUBLE PRECISION ZR, ZI, AIR, AII
+            END SUBROUTINE ZAIRY
+    end interface
 
-                call ZAIRY(zr, zi, id, kode, air, aii, nz, ierr)
+    call ZAIRY(zr, zi, id, kode, air, aii, nz, ierr)
 end subroutine zairy_wrap
 
 ! Airy function of the second kind.
 subroutine zbiry_wrap(zr, zi, id, kode, bir, bii, ierr) bind(C)
+    !DEC$ ATTRIBUTES DLLEXPORT :: zbiry_wrap
 
-                ! State ISO_C_BINDING and no implicit variable types.
-                use iso_c_binding
-                implicit none
+    ! State ISO_C_BINDING and no implicit variable types.
+    use iso_c_binding
+    implicit none
 
-                ! State intent of FORTRAN variables.
-                real(c_double), value, intent(in)               :: zr, zi
-                integer(c_int), value, intent(in)               :: id, kode
-                real(c_double), intent(out)                     :: bir, bii
-                integer(c_int), intent(out)                     :: ierr
+    ! State intent of FORTRAN variables.
+    real(c_double), value, intent(in)               :: zr, zi
+    integer(c_int), value, intent(in)               :: id, kode
+    real(c_double), intent(out)                     :: bir, bii
+    integer(c_int), intent(out)                     :: ierr
 
-                ! Interface to original FORTRAN subroutine.
-                interface
-                        SUBROUTINE BAIRY(ZR, ZI, ID, KODE, BIR, BII, IERR)
-                                INTEGER ID, KODE, IERR
-                                DOUBLE PRECISION ZR, ZI, BIR, BII
-                        END SUBROUTINE BAIRY
-                end interface
+    ! Interface to original FORTRAN subroutine.
+    interface
+            SUBROUTINE BAIRY(ZR, ZI, ID, KODE, BIR, BII, IERR)
+                    INTEGER ID, KODE, IERR
+                    DOUBLE PRECISION ZR, ZI, BIR, BII
+            END SUBROUTINE BAIRY
+    end interface
 
-                call ZBIRY(zr, zi, id, kode, bir, bii, ierr)
+    call ZBIRY(zr, zi, id, kode, bir, bii, ierr)
 end subroutine zbiry_wrap


### PR DESCRIPTION
Closes #18. Thanks @timmeh87 for this.

The `!DEC$` directives don't interfere with the GNU compiler. 

I'll test this myself on a Windows box, then add some documentation in the README. 